### PR TITLE
small update to suggest setting a higher request timeout value in LMStudio call

### DIFF
--- a/module-2/2-llamaindex-local-llm.ipynb
+++ b/module-2/2-llamaindex-local-llm.ipynb
@@ -61,6 +61,7 @@
     "    model_name=\"lmstudio-community/Meta-Llama-3-8B-Instruct-GGUF\",\n",
     "    base_url=\"http://localhost:1234/v1\",\n",
     "    temperature=0,\n",
+    "    # request_timeout=100, ## set this parameter to increase request time out if you're getting a 'request timed out' error\n",
     ")\n",
     "\n",
     "response = llm.complete(\"Hey there, what is 2+2?\")\n",


### PR DESCRIPTION
Hi @jaeyow ,

Just submitting a small one-liner comment to `module-2/2-llamaindex-local-llm.ipynb` python notebook.

For underpowered PCs with no dedicated CPU and lots of running processes, running a model could take longer than 30 seconds, and cause this request terminate early with a time out error. Setting a higher time out value than the default 30s is a workaround to allow the model to load in LMStudio successfully.

reference doc:
https://docs.llamaindex.ai/en/stable/api_reference/llms/lmstudio/?h=lmstud
